### PR TITLE
2020.26/ENG-5349 - FS: UI – All combo-boxes needs to be accessible

### DIFF
--- a/src/bootstrap/select.tpl.html
+++ b/src/bootstrap/select.tpl.html
@@ -1,9 +1,9 @@
 <div class="ui-select-container ui-select-bootstrap dropdown" ng-class="{open: $select.open}">
   <div class="ui-select-match"></div>
   <span ng-show="$select.open && $select.refreshing  && $select.spinnerEnabled" class="ui-select-refreshing {{$select.spinnerClass}}"></span>
-  <input type="search" autocomplete="off" tabindex="0"
+  <input type="search" autocomplete="off" tabindex="-1"
          role="combobox"
-         aria-expanded="{{$select.open}}"
+         aria-expanded="true"
          aria-label="{{ $select.baseTitle }}"
          aria-owns="ui-select-choices-{{ $select.generatedId }}"
          class="form-control ui-select-search"

--- a/src/bootstrap/select.tpl.html
+++ b/src/bootstrap/select.tpl.html
@@ -1,8 +1,9 @@
 <div class="ui-select-container ui-select-bootstrap dropdown" ng-class="{open: $select.open}">
   <div class="ui-select-match"></div>
   <span ng-show="$select.open && $select.refreshing  && $select.spinnerEnabled" class="ui-select-refreshing {{$select.spinnerClass}}"></span>
-  <input type="search" autocomplete="off" tabindex="-1"
-         aria-expanded="true"
+  <input type="search" autocomplete="off" tabindex="0"
+         role="combobox"
+         aria-expanded="{{$select.open}}"
          aria-label="{{ $select.baseTitle }}"
          aria-owns="ui-select-choices-{{ $select.generatedId }}"
          class="form-control ui-select-search"

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -41,7 +41,7 @@ uis.directive('uiSelect',
 
         $select.generatedId = uiSelectConfig.generateId();
         $select.baseTitle = attrs.title || 'Select box';
-        $select.focusserTitle = $select.baseTitle + ' focus';
+        $select.focusserTitle = $select.baseTitle;
         $select.focusserId = 'focusser-' + $select.generatedId;
 
         $select.closeOnSelect = function() {

--- a/src/uiSelectSingleDirective.js
+++ b/src/uiSelectSingleDirective.js
@@ -84,7 +84,7 @@ uis.directive('uiSelectSingle', ['$timeout','$compile', function($timeout, $comp
       });
 
       //Idea from: https://github.com/ivaynberg/select2/blob/79b5bf6db918d7560bdd959109b7bcfb47edaf43/select2.js#L1954
-      var focusser = angular.element("<input ng-disabled='$select.disabled' class='ui-select-focusser ui-select-offscreen' type='text' id='{{ $select.focusserId }}' aria-label='{{ $select.focusserTitle }}' aria-haspopup='true' role='button' />");
+      var focusser = angular.element("<input ng-disabled='$select.disabled' class='ui-select-focusser ui-select-offscreen' type='text' id='{{ $select.focusserId }}' aria-label='{{ $select.focusserTitle }}' aria-haspopup='true' role='combobox' />");
       $compile(focusser)(scope);
       $select.focusser = focusser;
 


### PR DESCRIPTION
## JIRA ticket

https://interfolio.atlassian.net/browse/ENG-5349

## Why?

Position Combo-box inaccessible and non-standard: Combo-box to "search or select unit" is non-standard and keyboard inaccessible. Upon focus, it reads "Select Box Focus Menu Button editable has autocomplete blank". 

## How?

By setting role 'combobox' to the input elements and editing the aria-label, expanded 

## Checklist

- [ ] Unit Tests
- [ ] Accessibility
- [ ] Performance

## Screenshots

NVDA screen reader outputs

### Before
![Before fix](https://user-images.githubusercontent.com/1175631/102094511-6f408980-3e48-11eb-92f9-b7cc3be974d9.png)

### After
![After fix](https://user-images.githubusercontent.com/1175631/102094226-17098780-3e48-11eb-976a-12ae3a3f5d72.png)

## Other Notes
