### PR TITLE
Bump up version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/Interfolio/ui-select.git"
   },
   "style": "dist/select.css",
-  "version": "0.19.9",
+  "version": "0.19.10",
   "devDependencies": {
     "angular": "^1.2.18",
     "angular-mocks": "^1.2.18",


### PR DESCRIPTION
Bump the version number

we bump this version number, so that can be used in medicine-cabinet repo